### PR TITLE
[STS-6] exclude pinned tabs from sort

### DIFF
--- a/package_for_web_store.sh
+++ b/package_for_web_store.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION="0.2.1"
+VERSION="0.3.0"
 
 # Replace version number if not already done so...
 gsed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/g" src/manifest.json
@@ -11,5 +11,7 @@ gsed -i s/UA-XXXXXXXXX-X/$STS_GA_TRACKING_ID/g src/analytics.js
 # Zip src dir for upload to the Chrome Web Store
 zip -r simple-tab-sorter-v$VERSION.zip src
 
-# Revert tracking id change to src/analytics.js to prevent if from being unintentionally committed to GitHub
+# Revert tracking id change to src/analytics.js to prevent it from being unintentionally committed to GitHub
 git checkout HEAD -- src/analytics.js
+
+# TODO: Look into https://github.com/github-tools/github-release-notes

--- a/package_for_web_store.sh
+++ b/package_for_web_store.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION="0.1.1"
+VERSION="0.2.1"
 
 # Replace version number if not already done so...
 gsed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/g" src/manifest.json

--- a/src/background.js
+++ b/src/background.js
@@ -21,16 +21,19 @@ chrome.runtime.onInstalled.addListener(function (details) {
 
 Please review the "User Guide" before getting started.`);
             window.open(chrome.runtime.getURL('userguide.html'));
-        } else if (details.reason == "update" && thisVersion == "0.2.0") {
+            // Set uninstall URL to Google feedback form if browser supports it...
+            if (chrome.runtime.setUninstallURL) {
+                var uninstallGoogleFormLink = 'https://docs.google.com/forms/d/e/1FAIpQLSe-r_WFNry_KZCwOjdMjDjiS8sEIWmmwY-3hbSmIYV393RLCA/viewform';
+                chrome.runtime.setUninstallURL(uninstallGoogleFormLink);
+            }
+        } else if (details.reason == "update" && thisVersion == "0.3.0") {
             chrome.storage.sync.get({
                 sortBy: 'url',
             }, function (items) {
                 if (items.sortBy == "url") {
-                    alert(`Simple Tab Sorter has been updated to v0.2.0.
+                    alert(`Simple Tab Sorter has been updated to v0.3.0.
 
-Please note that "Sort By: URL" now sorts strictly by URL and that "Sort By: Custom" has been added to support the previous "Sort By: URL" behavior.
-
-Your settings have been changed from "Sort By: URL" to "Sort By: Custom" to preserve the behavior you have been using.
+Please note that "Sort pinned tabs" has been added to the "Settings" page and is disabled by default.
 
 Please review the updated User Guide to learn about the latest changes.`);
                     chrome.storage.sync.set({
@@ -58,15 +61,16 @@ chrome.browserAction.onClicked.addListener(function (tab) {
                 sortBy: "url",
                 groupFrom: "leftToRight",
                 preserveOrderWithinGroups: false,
-                groupSuspendedTabs: false
+                groupSuspendedTabs: false,
+                sortPinnedTabs: false
             }, function (result) {
                switch (result.sortBy) {
                    case "url":
                    case "title":
-                       sortByTitleOrUrl(tabs, result.sortBy, result.groupSuspendedTabs);
+                       sortByTitleOrUrl(tabs, result.sortBy, result.groupSuspendedTabs, result.sortPinnedTabs);
                        break;
                    case "custom":
-                       sortByCustom(tabs, result.groupFrom, result.groupSuspendedTabs, result.preserveOrderWithinGroups);
+                       sortByCustom(tabs, result.groupFrom, result.groupSuspendedTabs, result.preserveOrderWithinGroups, result.sortPinnedTabs);
                        break;
                     default:
                         alert('Invalid sort-by condition encountered!');
@@ -119,19 +123,20 @@ function compareByUrlComponents(urlA, urlB) {
 }
 
 // Group suspended tabs to left side if 'groupSuspendedTabs' is checked in settings
-function sortByTitleOrUrl(tabs, sortBy, groupSuspendedTabs) {
+function sortByTitleOrUrl(tabs, sortBy, groupSuspendedTabs, sortPinnedTabs) {
     // Group suspended tabs to the left, using comparator for unsuspended tabs.
     tabs.sort(function (a, b) {
         if (sortBy == "title") {
-            return _titleComparator(a, b, groupSuspendedTabs);
+            return _titleComparator(a, b, groupSuspendedTabs, sortPinnedTabs);
         } else {
-            return _urlComparator(a, b, groupSuspendedTabs);
+            return _urlComparator(a, b, groupSuspendedTabs, sortPinnedTabs);
         }
     });
 
     // Shift suspended tabs left (if groupSuspendedTabs == true). Otherwise, sort by title in the browser's current locale.
-    function _titleComparator(a, b, groupSuspendedTabs) {
-        if (a.pinned || b.pinned) {
+    function _titleComparator(a, b, groupSuspendedTabs, sortPinnedTabs) {
+        // Fix for Issue #6 - Option to exclude pinned tabs in the sort action (excluded by default now)
+        if (!sortPinnedTabs && (a.pinned || b.pinned)) {
             return 0;
         }
 
@@ -143,8 +148,8 @@ function sortByTitleOrUrl(tabs, sortBy, groupSuspendedTabs) {
     }
 
     // Shift suspended tabs left (if groupSuspendedTabs == true). Otherwise, sort by URL in the browser's current locale.
-    function _urlComparator(a, b, groupSuspendedTabs) {
-        if (a.pinned || b.pinned) {
+    function _urlComparator(a, b, groupSuspendedTabs, sortPinnedTabs) {
+        if (!sortPinnedTabs && (a.pinned || b.pinned)) {
             return 0;
         }
 
@@ -162,7 +167,7 @@ function sortByTitleOrUrl(tabs, sortBy, groupSuspendedTabs) {
 }
 
 // Sort by URL as defined by the configured extension settings
-function sortByCustom(tabs, groupFrom, groupSuspendedTabs, preserveOrderWithinGroups) {
+function sortByCustom(tabs, groupFrom, groupSuspendedTabs, preserveOrderWithinGroups, sortPinnedTabs) {
     var tabGroupMap = new Map();
     var left = 0, suspendedTabCount = 0, right = tabs.length;
 
@@ -193,7 +198,7 @@ function sortByCustom(tabs, groupFrom, groupSuspendedTabs, preserveOrderWithinGr
         }
     }
 
-    tabs.sort(function (a, b) { return _customSortComparator(a, b, groupSuspendedTabs); });
+    tabs.sort(function (a, b) { return _customSortComparator(a, b, groupSuspendedTabs, sortPinnedTabs); });
 
     // Support independent subsorting of suspended tabs if 'groupSuspendedTabs' is checked in settings
     if (groupSuspendedTabs) {
@@ -219,8 +224,8 @@ function sortByCustom(tabs, groupFrom, groupSuspendedTabs, preserveOrderWithinGr
         tabs.push.apply(tabs, suspendedTabs.concat(postSorted));
     }
 
-    function _customSortComparator(a, b, groupSuspendedTabs) {
-        if (a.pinned || b.pinned) {
+    function _customSortComparator(a, b, groupSuspendedTabs, sortPinnedTabs) {
+        if (!sortPinnedTabs && (a.pinned || b.pinned)) {
             return 0;
         }
 

--- a/src/background.js
+++ b/src/background.js
@@ -11,9 +11,12 @@ function isSuspended(tab) {
 
 // One-time installation and v0.2.0 upgrade handlers...
 chrome.runtime.onInstalled.addListener(function (details) {
+
+    // TODO: Track removals, eventually do something like https://shivankaul.com/blog/feedback-form-for-chrome-extensions (add for both install and update)
     try {
         var thisVersion = chrome.runtime.getManifest().version;
         if (details.reason == "install") {
+            _gaq.push(['_trackEvent', 'Simple Tab Sorter extension', 'installed']);
             alert(`Welcome to Simple Tab Sorter!
 
 Please review the "User Guide" before getting started.`);
@@ -128,6 +131,10 @@ function sortByTitleOrUrl(tabs, sortBy, groupSuspendedTabs) {
 
     // Shift suspended tabs left (if groupSuspendedTabs == true). Otherwise, sort by title in the browser's current locale.
     function _titleComparator(a, b, groupSuspendedTabs) {
+        if (a.pinned || b.pinned) {
+            return 0;
+        }
+
         if (groupSuspendedTabs) {
             if (isSuspended(a) && !isSuspended(b)) return -1;
             if (!isSuspended(a) && isSuspended(b)) return 1;
@@ -137,6 +144,10 @@ function sortByTitleOrUrl(tabs, sortBy, groupSuspendedTabs) {
 
     // Shift suspended tabs left (if groupSuspendedTabs == true). Otherwise, sort by URL in the browser's current locale.
     function _urlComparator(a, b, groupSuspendedTabs) {
+        if (a.pinned || b.pinned) {
+            return 0;
+        }
+
         // Shift suspended tabs left...
         if (groupSuspendedTabs) {
             if (isSuspended(a) && !isSuspended(b)) return -1;
@@ -209,6 +220,10 @@ function sortByCustom(tabs, groupFrom, groupSuspendedTabs, preserveOrderWithinGr
     }
 
     function _customSortComparator(a, b, groupSuspendedTabs) {
+        if (a.pinned || b.pinned) {
+            return 0;
+        }
+
         // Shift suspended tabs left...
         if (groupSuspendedTabs) {
             if (isSuspended(a) && !isSuspended(b)) return -1;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Simple Tab Sorter",
     "description": "Simple tab sorter that allows user-defined tab group order.",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "permissions": ["tabs", "storage"],
     "browser_action": {
         "default_title": "Simple Tab Sorter"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Simple Tab Sorter",
     "description": "Simple tab sorter that allows user-defined tab group order.",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "permissions": ["tabs", "storage"],
     "browser_action": {
         "default_title": "Simple Tab Sorter"

--- a/src/options.html
+++ b/src/options.html
@@ -54,6 +54,12 @@
                             Group <a href="https://chrome.google.com/webstore/detail/the-great-suspender/klbibkeccnjlkjkiokjodocebajanakg" target="_blank">suspended</a> tabs together
                         </label>
                     </div>
+                    <div class="form-check">
+                        <input type="checkbox" class="form-check-input" id="sortPinnedTabs" name="sortPinnedTabs">
+                        <label class="form-check-label" for="sortPinnedTabs">
+                            Sort pinned tabs
+                        </label>
+                    </div>
                 </div>
                 <div class="setting-group">
                     <div class="form-group">

--- a/src/options.js
+++ b/src/options.js
@@ -4,11 +4,13 @@ function saveOptions() {
     var groupFrom = document.getElementById('groupFrom').value;
     var preserveOrderWithinGroups = document.getElementById('preserveOrderWithinGroups').checked;
     var groupSuspendedTabs = document.getElementById('groupSuspendedTabs').checked;
+    var sortPinnedTabs = document.getElementById('sortPinnedTabs').checked;
     chrome.storage.sync.set({
         sortBy: sortBy,
         groupFrom: groupFrom,
         preserveOrderWithinGroups: preserveOrderWithinGroups,
-        groupSuspendedTabs: groupSuspendedTabs
+        groupSuspendedTabs: groupSuspendedTabs,
+        sortPinnedTabs: sortPinnedTabs
     }, function () {
         document.getElementById('save').setAttribute("disabled", true);
         // Show status to let user know changes were saved
@@ -24,13 +26,15 @@ function restoreOptions() {
         sortBy: 'custom',
         groupFrom: 'leftToRight',
         preserveOrderWithinGroups: true,
-        groupSuspendedTabs: false
+        groupSuspendedTabs: false,
+        sortPinnedTabs: false
     }, function (items) {
         toggleTabGroupOptions(items.sortBy);
         document.getElementById('sortBy').value = items.sortBy;
         document.getElementById('groupFrom').value = items.groupFrom;
         document.getElementById('preserveOrderWithinGroups').checked = items.preserveOrderWithinGroups;
         document.getElementById('groupSuspendedTabs').checked = items.groupSuspendedTabs;
+        document.getElementById('sortPinnedTabs').checked = items.sortPinnedTabs;
     });
 }
 
@@ -39,12 +43,14 @@ function toggleSaveButton() {
         sortBy: 'custom',
         groupFrom: 'leftToRight',
         preserveOrderWithinGroups: true,
-        groupSuspendedTabs: false
+        groupSuspendedTabs: false,
+        sortPinnedTabs: false
     }, function (items) {
         if (document.getElementById('sortBy').value != items.sortBy ||
             document.getElementById('groupFrom').value != items.groupFrom ||
             document.getElementById('preserveOrderWithinGroups').checked != items.preserveOrderWithinGroups ||
-            document.getElementById('groupSuspendedTabs').checked != items.groupSuspendedTabs) {
+            document.getElementById('groupSuspendedTabs').checked != items.groupSuspendedTabs ||
+            document.getElementById('sortPinnedTabs').checked != items.sortPinnedTabs) {
             document.getElementById('save').removeAttribute("disabled");
             // Hide status to reflect that changes have not been saved
             $('#status').removeClass("visible");
@@ -77,4 +83,5 @@ document.getElementById('sortBy').addEventListener('change', function() {
 document.getElementById('groupFrom').addEventListener('change', toggleSaveButton);
 document.getElementById('preserveOrderWithinGroups').addEventListener('change', toggleSaveButton);
 document.getElementById('groupSuspendedTabs').addEventListener('change', toggleSaveButton);
+document.getElementById('sortPinnedTabs').addEventListener('change', toggleSaveButton);
 document.getElementById('save').addEventListener('click', saveOptions);

--- a/src/userguide.html
+++ b/src/userguide.html
@@ -80,6 +80,10 @@
                                         all suspended tabs will be shifted to the far left side of your browser and maintain their relative position to each other unless "<em>Preserve order within groups</em>" is <strong>deselected</strong>,
                                         in which case the suspended tabs will be subsorted by URL.
                                     </p>
+                                    <h5>Sort pinned tabs</h5>
+                                    <p>
+                                        Simple Tab Sorter <b>ignores</b> pinned tabs by default. If you check the box, pinned tabs will remain grouped together but will be sub-sorted by the same criteria used to sort the rest of your tabs.
+                                    </p>
                                 </td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
* Added "Sort pinned tabs" setting and disabled it by default
* Updated documentation to reflect new setting and behavior
* Added Google Form to collect user feedback when extension is removed